### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#Unity Pixel Art Toolkit
+# Unity Pixel Art Toolkit
 
-#####A free Pixel Art Toolkit for the [Unity Engine](http://unity3d.com).
+##### A free Pixel Art Toolkit for the [Unity Engine](http://unity3d.com).
 
 UPA Toolkit makes it fast and easy to create Pixel Art sprites without leaving the comfort of Unity. It's seamlessly integrated with the awesome 2D features introduced with Unity 4.3 making it a breeze to use. UPA Toolkit is sure to speed up your workflow by utilising the effective Unity feedback loop and great image capabilities.
 
@@ -8,12 +8,12 @@ UPA Toolkit is written solely in C#.
 
 This project is open for contributions. See [this guide](https://guides.github.com/activities/contributing-to-open-source/) on contributing to projects on GitHub. Also check out TODO.md for inspiration on future improvements and bug fixes.
 
-###Download
+### Download
 Download from the Unity Asset Store [here](http://u3d.as/aZ3).
 The newest release can be found in the /Builds/ folder or under [releases](https://github.com/Brackeys/UPAToolkit/releases).
 
-###Software Requirements
+### Software Requirements
 This project is fully compatible with [Unity](http://unity3d.com) Personal Edition.
 
-###Copyright
+### Copyright
 See LICENSE.

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
-##TODO List
+## TODO List
 (The following list is in no particular order.)
 
-####Features & Improvements
+#### Features & Improvements
 - Add BoxBrush for coloring multiple pixels at once
 - Add secondary color for easy switching
 - Add grab tool (alt + left click)
@@ -9,6 +9,6 @@
 - Add move tool
 - Generate grid as image instead of drawing rects
 
-####Bug fixes
+#### Bug fixes
 - Fix image zooming on Mac
 - Revisit shortcuts on windows


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
