### PR TITLE
Fixed 2 warnings in Unity 2017.2.1f1

### DIFF
--- a/Assets/UPAToolkit/Editor/UPASession.cs
+++ b/Assets/UPAToolkit/Editor/UPASession.cs
@@ -166,7 +166,7 @@ public class UPASession {
 		}
 		
 		texImp.filterMode = FilterMode.Point;
-		texImp.textureFormat = TextureImporterFormat.AutomaticTruecolor;
+		texImp.textureCompression = TextureImporterCompression.Uncompressed;
 		
 		AssetDatabase.ImportAsset(path); 
 		


### PR DESCRIPTION
textureFormat is obsolete and is replaced with textureCompression. TextureImporterFormat.AutomaticTruecolor is obsolete as well and has been replaced with TextureImporterCompression.Uncompressed